### PR TITLE
Destroy a minor account

### DIFF
--- a/app/commands/decidim/kids/destroy_minor_account.rb
+++ b/app/commands/decidim/kids/destroy_minor_account.rb
@@ -12,7 +12,7 @@ module Decidim
       def call
         transaction do
           delete_minor_user!
-          destroy_minor_data unless @minor_user.confirmed?
+          destroy_minor_data
           destroy_minor_account
         end
 

--- a/app/commands/decidim/kids/destroy_minor_account.rb
+++ b/app/commands/decidim/kids/destroy_minor_account.rb
@@ -13,9 +13,9 @@ module Decidim
 
       def call
         transaction do
-          destroy_minor_user
           destroy_minor_data
           destroy_minor_account
+          destroy_minor_user
         end
 
         broadcast(:ok)

--- a/app/commands/decidim/kids/destroy_minor_account.rb
+++ b/app/commands/decidim/kids/destroy_minor_account.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Kids
+    # This command destroys the minor's account.
+    class DestroyMinorAccount < Decidim::Command
+      def initialize(minor_user, minor_account)
+        @minor_user = minor_user
+        @minor_account = minor_account
+      end
+
+      def call
+        transaction do
+          delete_minor_user!
+          destroy_minor_data unless @minor_user.confirmed?
+          destroy_minor_account
+        end
+
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :minor_user, :minor_account
+
+      def delete_minor_user!
+        @minor_user.name = ""
+        @minor_user.email = ""
+        @minor_user.name = ""
+        @minor_user.nickname = ""
+        @minor_user.deleted_at = Time.current
+        @minor_user.skip_reconfirmation!
+        @minor_user.save!
+      end
+
+      def destroy_minor_data
+        @minor_user.minor_data.destroy!
+      end
+
+      def destroy_minor_account
+        @minor_account.destroy_all
+      end
+    end
+  end
+end

--- a/app/controllers/decidim/kids/user_minors_controller.rb
+++ b/app/controllers/decidim/kids/user_minors_controller.rb
@@ -62,6 +62,20 @@ module Decidim
         end
       end
 
+      def destroy
+        DestroyMinorAccount.call(minor_user, minor_account) do
+          on(:ok) do
+            flash[:notice] = t("user_minors.destroy.success", scope: "decidim.kids")
+          end
+
+          on(:invalid) do
+            flash[:alert] = t("user_minors.destroy.error", scope: "decidim.kids")
+          end
+        end
+
+        redirect_to user_minors_path
+      end
+
       private
 
       def minor_account_form
@@ -70,6 +84,10 @@ module Decidim
 
       def minor_user
         @minor_user ||= minors.find_by(id: params[:id])
+      end
+
+      def minor_account
+        @minor_account ||= Decidim::Kids::MinorAccount.where(decidim_minor_id: minor_user.id)
       end
     end
   end

--- a/app/controllers/decidim/kids/user_minors_controller.rb
+++ b/app/controllers/decidim/kids/user_minors_controller.rb
@@ -63,6 +63,8 @@ module Decidim
       end
 
       def destroy
+        enforce_permission_to :delete, :minor_accounts, minor_user: minor_user
+
         DestroyMinorAccount.call(minor_user, minor_account) do
           on(:ok) do
             flash[:notice] = t("user_minors.destroy.success", scope: "decidim.kids")

--- a/app/controllers/decidim/kids/user_minors_controller.rb
+++ b/app/controllers/decidim/kids/user_minors_controller.rb
@@ -69,10 +69,6 @@ module Decidim
           on(:ok) do
             flash[:notice] = t("user_minors.destroy.success", scope: "decidim.kids")
           end
-
-          on(:invalid) do
-            flash[:alert] = t("user_minors.destroy.error", scope: "decidim.kids")
-          end
         end
 
         redirect_to user_minors_path

--- a/app/helpers/decidim/kids/application_helper.rb
+++ b/app/helpers/decidim/kids/application_helper.rb
@@ -5,6 +5,7 @@ module Decidim
     # Custom helpers, scoped to the kids engine.
     #
     module ApplicationHelper
+      include Decidim::Admin::IconLinkHelper
     end
   end
 end

--- a/app/permissions/decidim/kids/permissions.rb
+++ b/app/permissions/decidim/kids/permissions.rb
@@ -20,6 +20,8 @@ module Decidim
               can_create_minor_account?
             when :edit
               can_edit_minor_account?
+            when :delete
+              can_destroy_minor_account?
             end
           end
         end
@@ -39,6 +41,10 @@ module Decidim
 
       def can_edit_minor_account?
         toggle_allow(user.minors.include?(minor_user))
+      end
+
+      def can_destroy_minor_account?
+        can_edit_minor_account?
       end
     end
   end

--- a/app/views/decidim/kids/user_minors/index.html.erb
+++ b/app/views/decidim/kids/user_minors/index.html.erb
@@ -10,13 +10,17 @@ list my kids
     Age:
     <%= user.minor_age %>
     <br>
-    <%= link_to t(".edit"), decidim_kids.edit_user_minor_path(user.id) %>
+    <% if allowed_to? :edit, :minor_accounts, minor_user: user %>
+      <%= link_to t(".edit"), decidim_kids.edit_user_minor_path(user.id) %>
+    <% end %>
     <br>
-    <%= icon_link_to "circle-x", decidim_kids.user_minor_path(user.id),
-                     t('.destroy_button'),
-                     method: :delete,
-                     data: { confirm: t('.confirm') },
-                     class: "action-icon action-icon--remove" %>
+    <% if allowed_to? :delete, :minor_accounts, minor_user: user %>
+      <%= icon_link_to "circle-x", decidim_kids.user_minor_path(user.id),
+                       t('.destroy_button'),
+                       method: :delete,
+                       data: { confirm: t('.confirm') },
+                       class: "action-icon action-icon--remove" %>
+    <% end %>
   </li>
 <% end %>
 <br>

--- a/app/views/decidim/kids/user_minors/index.html.erb
+++ b/app/views/decidim/kids/user_minors/index.html.erb
@@ -11,6 +11,12 @@ list my kids
     <%= user.minor_age %>
     <br>
     <%= link_to t(".edit"), decidim_kids.edit_user_minor_path(user.id) %>
+    <br>
+    <%= icon_link_to "circle-x", decidim_kids.user_minor_path(user.id),
+                     t('.destroy_button'),
+                     method: :delete,
+                     data: { confirm: t('.confirm') },
+                     class: "action-icon action-icon--remove" %>
   </li>
 <% end %>
 <br>

--- a/app/views/decidim/kids/user_minors/index.html.erb
+++ b/app/views/decidim/kids/user_minors/index.html.erb
@@ -16,9 +16,9 @@ list my kids
     <br>
     <% if allowed_to? :delete, :minor_accounts, minor_user: user %>
       <%= icon_link_to "circle-x", decidim_kids.user_minor_path(user.id),
-                       t('.destroy_button'),
+                       t(".destroy_button"),
                        method: :delete,
-                       data: { confirm: t('.confirm') },
+                       data: { confirm: t(".confirm") },
                        class: "action-icon action-icon--remove" %>
     <% end %>
   </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,13 +59,13 @@ en:
           success: Minor's account has been successfully created
         destroy:
           error: Errors occurred while deleting a minor's account
-          success: Minor's account has been successfully destroyed
+          success: Minor's account has been successfully deleted
         edit:
           edit_button: Update minor account
           title: Edit minor account
         index:
           add: Add a minor
-          confirm: Are you sure you want to destroy minor's account?
+          confirm: Are you sure you want to delete minor's account?
           destroy_button: Delete
           edit: Edit
           note: Maximum number of minors reached

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,11 +57,16 @@ en:
         create:
           error: Errors occurred while creating a minor's account
           success: Minor's account has been successfully created
+        destroy:
+          error: Errors occurred while deleting a minor's account
+          success: Minor's account has been successfully destroyed
         edit:
           edit_button: Update minor account
           title: Edit minor account
         index:
           add: Add a minor
+          confirm: Are you sure you want to destroy minor's account?
+          destroy_button: Delete
           edit: Edit
           note: Maximum number of minors reached
         new:

--- a/spec/commands/destroy_minor_account_spec.rb
+++ b/spec/commands/destroy_minor_account_spec.rb
@@ -8,7 +8,7 @@ module Decidim::Kids
     let(:organization) { create :organization }
     let(:user) { create(:user, :confirmed, organization:) }
     let(:minor) { create(:minor, tutor: user, organization:) }
-    let(:minor_account) { MinorAccount.where(decidim_minor_id: minor.id) }
+    let!(:minor_account) { Decidim::Kids::MinorAccount.where(decidim_minor_id: minor.id) }
 
     it "broadcasts ok" do
       expect { command.call }.to broadcast(:ok)
@@ -19,6 +19,12 @@ module Decidim::Kids
       expect(minor.reload.name).to eq("")
       expect(minor.reload.nickname).to eq("")
       expect(minor.reload.email).to eq("")
+    end
+
+    it "deletes minor's account" do
+      expect do
+        command.call
+      end.to change(Decidim::Kids::MinorAccount, :count).by(-1)
     end
   end
 end

--- a/spec/commands/destroy_minor_account_spec.rb
+++ b/spec/commands/destroy_minor_account_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Kids
+  describe DestroyMinorAccount do
+    let(:command) { described_class.new(minor, minor_account) }
+    let(:organization) { create :organization }
+    let(:user) { create(:user, :confirmed, organization:) }
+    let(:minor) { create(:minor, tutor: user, organization:) }
+    let(:minor_account) { MinorAccount.where(decidim_minor_id: minor.id) }
+
+    it "broadcasts ok" do
+      expect { command.call }.to broadcast(:ok)
+    end
+
+    it "set name, nickname and email to blank string" do
+      command.call
+      expect(minor.reload.name).to eq("")
+      expect(minor.reload.nickname).to eq("")
+      expect(minor.reload.email).to eq("")
+    end
+  end
+end

--- a/spec/commands/destroy_minor_account_spec.rb
+++ b/spec/commands/destroy_minor_account_spec.rb
@@ -7,24 +7,47 @@ module Decidim::Kids
     let(:command) { described_class.new(minor, minor_account) }
     let(:organization) { create :organization }
     let(:user) { create(:user, :confirmed, organization:) }
-    let(:minor) { create(:minor, tutor: user, organization:) }
+    let(:minor) { create(:minor, tutor: user, organization:, sign_in_count:) }
     let!(:minor_account) { Decidim::Kids::MinorAccount.where(decidim_minor_id: minor.id) }
+    let(:sign_in_count) { 1 }
 
-    it "broadcasts ok" do
-      expect { command.call }.to broadcast(:ok)
-    end
+    context "when a minor user is confirmed" do
+      it "broadcasts ok" do
+        expect { command.call }.to broadcast(:ok)
+      end
 
-    it "set name, nickname and email to blank string" do
-      command.call
-      expect(minor.reload.name).to eq("")
-      expect(minor.reload.nickname).to eq("")
-      expect(minor.reload.email).to eq("")
-    end
-
-    it "deletes minor's account" do
-      expect do
+      it "set name, nickname and email to blank string" do
         command.call
-      end.to change(Decidim::Kids::MinorAccount, :count).by(-1)
+        expect(minor.reload.name).to eq("")
+        expect(minor.reload.nickname).to eq("")
+        expect(minor.reload.email).to eq("")
+      end
+
+      it "deletes minor's account" do
+        expect do
+          command.call
+        end.to change(Decidim::Kids::MinorAccount, :count).by(-1)
+      end
+    end
+
+    context "when a minor user is not confirmed" do
+      let(:sign_in_count) { 0 }
+
+      it "broadcasts ok" do
+        expect { command.call }.to broadcast(:ok)
+      end
+
+      it "deletes minor" do
+        expect do
+          command.call
+        end.to change(Decidim::User, :count).by(-1)
+      end
+
+      it "deletes minor's account" do
+        expect do
+          command.call
+        end.to change(Decidim::Kids::MinorAccount, :count).by(-1)
+      end
     end
   end
 end

--- a/spec/controllers/user_minors_controller_spec.rb
+++ b/spec/controllers/user_minors_controller_spec.rb
@@ -153,7 +153,7 @@ module Decidim::Kids
         it "deletes the minor" do
           delete :destroy, params: { id: minor.id }
 
-          expect(flash[:notice]).to eq("Minor's account has been successfully destroyed")
+          expect(flash[:notice]).to eq("Minor's account has been successfully deleted")
           expect(MinorAccount.count).to eq(0)
         end
       end

--- a/spec/controllers/user_minors_controller_spec.rb
+++ b/spec/controllers/user_minors_controller_spec.rb
@@ -153,7 +153,7 @@ module Decidim::Kids
         it "deletes the minor" do
           delete :destroy, params: { id: minor.id }
 
-          expect(flash[:notice]).not_to eq("Minor's account has been successfully deleted")
+          expect(flash[:notice]).to eq("Minor's account has been successfully destroyed")
           expect(MinorAccount.count).to eq(0)
         end
       end

--- a/spec/controllers/user_minors_controller_spec.rb
+++ b/spec/controllers/user_minors_controller_spec.rb
@@ -148,6 +148,15 @@ module Decidim::Kids
           expect(controller).to render_template "edit"
         end
       end
+
+      describe "DELETE destroy" do
+        it "deletes the minor" do
+          delete :destroy, params: { id: minor.id }
+
+          expect(flash[:notice]).not_to eq("Minor's account has been successfully deleted")
+          expect(MinorAccount.count).to eq(0)
+        end
+      end
     end
   end
 end

--- a/spec/permissions/permissions_spec.rb
+++ b/spec/permissions/permissions_spec.rb
@@ -69,6 +69,24 @@ module Decidim::Kids
       it { is_expected.to be true }
     end
 
+    context "when destroy action" do
+      let(:action_name) { :delete }
+      let(:minor_account) { Decidim::Kids::MinorAccount.where(decidim_minor_id: minor.id) }
+
+      let(:context) do
+        {
+          minor_user: minor,
+          minor_account:
+        }
+      end
+
+      let(:action) do
+        { scope: :public, action: action_name, subject: action_subject }
+      end
+
+      it { is_expected.to be true }
+    end
+
     context "when other action" do
       let(:action_name) { :other_action }
 

--- a/spec/shared/user_minors_crud_examples.rb
+++ b/spec/shared/user_minors_crud_examples.rb
@@ -67,12 +67,12 @@ shared_examples "deletes minor accounts" do
   it "can delete a minor" do
     page.find("a.action-icon--remove").click
 
-    expect(page).to have_content("Are you sure you want to destroy minor's account?")
+    expect(page).to have_content("Are you sure you want to delete minor's account?")
 
     click_link("OK")
 
     within_flash_messages do
-      expect(page).to have_content("successfully destroyed")
+      expect(page).to have_content("successfully deleted")
     end
 
     expect(page).not_to have_content("Tesla")

--- a/spec/shared/user_minors_crud_examples.rb
+++ b/spec/shared/user_minors_crud_examples.rb
@@ -62,3 +62,19 @@ shared_examples "updates minor accounts" do
     expect(page).to have_content("Nikola Tesla")
   end
 end
+
+shared_examples "deletes minor accounts" do
+  it "can delete a minor" do
+    page.find("a.action-icon--remove").click
+
+    expect(page).to have_content("Are you sure you want to destroy minor's account?")
+
+    click_link("OK")
+
+    within_flash_messages do
+      expect(page).to have_content("successfully destroyed")
+    end
+
+    expect(page).not_to have_content("Tesla")
+  end
+end

--- a/spec/system/user_minor_accounts_spec.rb
+++ b/spec/system/user_minor_accounts_spec.rb
@@ -51,6 +51,7 @@ describe "User manages minor accounts", type: :system do
 
       it_behaves_like "creates minor accounts"
       it_behaves_like "updates minor accounts"
+      it_behaves_like "deletes minor accounts"
     end
 
     context "when the user is a minor" do


### PR DESCRIPTION
This PR adds the ability to remove a minor from the list. 

If the minor has never logged in, the user hard destroys.
If the user is logged in, the user will be softly destroyed, the minor's  account and minor data will be deleted.