### PR TITLE
Improvements minor account creation workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,8 @@ env:
 
 jobs:
   lint-report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   test-report:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     services:
       postgres:

--- a/app/commands/decidim/kids/create_minor_account.rb
+++ b/app/commands/decidim/kids/create_minor_account.rb
@@ -29,9 +29,7 @@ module Decidim
                                         blocked: true,
                                         blocked_at: Time.current,
                                         organization: @current_user.organization,
-                                        password: form.password,
                                         tos_agreement: true,
-                                        password_confirmation: form.password_confirmation,
                                         nickname: Decidim::User.nicknamize(form.name, organization: @current_user.organization),
                                         minor_data: MinorData.new({
                                                                     birthday: form.birthday,

--- a/app/commands/decidim/kids/destroy_minor_account.rb
+++ b/app/commands/decidim/kids/destroy_minor_account.rb
@@ -13,7 +13,6 @@ module Decidim
 
       def call
         transaction do
-          destroy_minor_data
           destroy_minor_account
           destroy_minor_user
         end
@@ -41,10 +40,6 @@ module Decidim
 
       def destroy_minor_user
         minor_user.sign_in_count? ? destroy_confirmed_minor_user! : destroy_not_confirmed_minor_user
-      end
-
-      def destroy_minor_data
-        @minor_user.minor_data.destroy!
       end
 
       def destroy_minor_account

--- a/app/commands/decidim/kids/update_minor_account.rb
+++ b/app/commands/decidim/kids/update_minor_account.rb
@@ -14,16 +14,8 @@ module Decidim
         old_minor_email = minor_user.email
 
         update_minor
-        update_minor_password
 
-        if minor_user.valid?
-          minor_user.save!
-        else
-          [:password, :password_confirmation].each do |key|
-            form.errors.add key, minor_user.errors[key] if minor_user.errors.has_key? key
-          end
-          return broadcast(:invalid)
-        end
+        minor_user.save!
 
         minor_user.minor_data.update!(attributes_data)
 
@@ -39,13 +31,6 @@ module Decidim
       def update_minor
         minor_user.skip_reconfirmation!
         minor_user.email = form.email
-      end
-
-      def update_minor_password
-        return if form.password.blank?
-
-        minor_user.password = form.password
-        minor_user.password_confirmation = form.password_confirmation
       end
 
       def attributes_data

--- a/app/forms/decidim/kids/minor_account_form.rb
+++ b/app/forms/decidim/kids/minor_account_form.rb
@@ -8,25 +8,16 @@ module Decidim
       attribute :name, String
       attribute :birthday, Decidim::Attributes::LocalizedDate
       attribute :email, String
-      attribute :password, String
-      attribute :password_confirmation, String
       attribute :tos_agreement, Boolean
 
       validates :name, presence: true
       validates :birthday, presence: true
       validates :email, presence: true, "valid_email_2/email": { disposable: true }
-      validates :password, confirmation: true
-      validates :password, presence: true, password: { name: :name, email: :email, username: :nickname }, if: :password_present
-      validates :password_confirmation, presence: true, if: :password_present
       validates :tos_agreement, acceptance: true
 
       validate :valid_minor_age
 
       private
-
-      def password_present
-        password.present?
-      end
 
       def valid_minor_age
         min_minor_age = Decidim::Kids.minimum_minor_age

--- a/app/forms/decidim/kids/minor_account_form.rb
+++ b/app/forms/decidim/kids/minor_account_form.rb
@@ -10,25 +10,16 @@ module Decidim
       attribute :name, String
       attribute :birthday, Decidim::Attributes::LocalizedDate
       attribute :email, String
-      attribute :password, String
-      attribute :password_confirmation, String
       attribute :tos_agreement, Boolean
 
       validates :name, presence: true
       validates :birthday, presence: true
       validates :email, presence: true, "valid_email_2/email": { disposable: true }
-      validates :password, confirmation: true
-      validates :password, presence: true, password: { name: :name, email: :email, username: :nickname }, if: :password_present
-      validates :password_confirmation, presence: true, if: :password_present
       validates :tos_agreement, acceptance: true
 
       validate :valid_minor_age
 
       private
-
-      def password_present
-        password.present?
-      end
 
       def valid_minor_age
         min_minor_age = Decidim::Kids.minimum_minor_age

--- a/app/models/concerns/decidim/kids/user_override.rb
+++ b/app/models/concerns/decidim/kids/user_override.rb
@@ -35,6 +35,12 @@ module Decidim
 
           age_from_birthday(minor_data_birthday)
         end
+
+        def password_required?
+          return false if managed? || minor_data.present?
+
+          super
+        end
       end
     end
   end

--- a/app/models/concerns/decidim/kids/user_override.rb
+++ b/app/models/concerns/decidim/kids/user_override.rb
@@ -34,6 +34,12 @@ module Decidim
 
           ((Time.zone.now - minor_data_birthday.to_time) / 1.year.seconds).floor
         end
+
+        def password_required?
+          return false if managed? || minor_data.present?
+
+          super
+        end
       end
     end
   end

--- a/app/views/decidim/kids/authorizations/new.html.erb
+++ b/app/views/decidim/kids/authorizations/new.html.erb
@@ -2,9 +2,11 @@
 <% content_for(:subtitle) { t("menu", scope: "decidim.kids.user") } %>
 
 <div class="callout secondary">
-<%= t(".authorizing_html", minor: minor_user.minor_data.name) %>
-<%= link_to "cancel", :back, class: "button secondary small float-right" %>
+  <%= t(".authorizing_html", minor: minor_user.minor_data.name) %>
+  <%= link_to "cancel", :back, class: "button secondary small float-right" %>
 </div>
+
+<div><%= t(".help_text") %></div>
 
 <div class="columns large-8 large-centered text-center page-title">
   <h2><%= t("decidim.verifications.authorizations.new.authorize_with", authorizer: t("#{handler.handler_name}.name", scope: "decidim.authorization_handlers")) %></h2>

--- a/app/views/decidim/kids/user_minors/_form_fields.html.erb
+++ b/app/views/decidim/kids/user_minors/_form_fields.html.erb
@@ -8,4 +8,5 @@
 
 <div class="field">
   <%= form.email_field :email %>
+  <span class="help-text"><%= t("new.help_text_email", scope: "decidim.kids.user_minors") %></span>
 </div>

--- a/app/views/decidim/kids/user_minors/_minor_tr.html.erb
+++ b/app/views/decidim/kids/user_minors/_minor_tr.html.erb
@@ -10,8 +10,11 @@
   <td>
     <%= confirm_email_status(user) %>
     <% if !minor_confirmed?(user) && minor_authorized?(user) %>
-      <%= link_to t("resend_email", scope: "decidim.kids.user_minors.index"),
-                  resend_invitation_to_minor_user_minor_path(user.id), method: :post %>
+      <%= icon_link_to "action-redo",
+                       resend_invitation_to_minor_user_minor_path(user.id),
+                       t("resend_email", scope: "decidim.kids.user_minors.index"),
+                       method: :post,
+                       class: "ml-xs" %>
     <% end %>
   </td>
 
@@ -21,7 +24,7 @@
 
   <td>
     <% if user.last_sign_in_at %>
-        <%= l user.last_sign_in_at, format: :short %>
+      <%= l user.last_sign_in_at, format: :short %>
     <% elsif !minor_authorized?(user) %>
       <span class="label warning"><%= t("needs_verification", scope: "decidim.kids.user_minors.index") %></span>
     <% end %>

--- a/app/views/decidim/kids/user_minors/_password_fields.html.erb
+++ b/app/views/decidim/kids/user_minors/_password_fields.html.erb
@@ -1,7 +1,0 @@
-<div class="field">
-  <%= form.password_field :password %>
-</div>
-
-<div class="field">
-  <%= form.password_field :password_confirmation %>
-</div>

--- a/app/views/decidim/kids/user_minors/edit.html.erb
+++ b/app/views/decidim/kids/user_minors/edit.html.erb
@@ -9,17 +9,6 @@
 
           <%= render partial: "form_fields", locals: { form: form } %>
 
-          <% if @form.errors[:password].any? || @form.errors[:password_confirmation].any? %>
-            <%= render partial: "password_fields", locals: { form: form } %>
-          <% else %>
-            <p>
-              <button type="button" data-toggle="passwordChange" class="link change-password"><%= t ".change_password" %></button>
-            </p>
-            <div id="passwordChange" class="toggle-show" data-toggler=".is-expanded">
-              <%= render partial: "password_fields", locals: { form: form } %>
-            </div>
-          <% end %>
-
           <div class="actions">
             <%= form.submit t(".edit_button"), class: "button expanded mt-s mb-none", data: { disable: true } %>
           </div>

--- a/app/views/decidim/kids/user_minors/new.html.erb
+++ b/app/views/decidim/kids/user_minors/new.html.erb
@@ -1,6 +1,7 @@
 <% content_for(:subtitle) { t("menu", scope: "decidim.kids.user") } %>
 <div class="row">
-  <h3 class="section flex-center"><%= t(".title") %></h3>
+  <h3 class="flex-center"><%= t(".title") %></h3>
+  <p class="flex-center mb-s"><%= t(".subtitle") %></p>
   <div class="columns large-6 medium-10 medium-centered">
     <div class="card">
       <div class="card__content">

--- a/app/views/decidim/kids/user_minors/new.html.erb
+++ b/app/views/decidim/kids/user_minors/new.html.erb
@@ -10,8 +10,6 @@
 
           <%= render partial: "form_fields", locals: { form: form } %>
 
-          <%= render partial: "password_fields", locals: { form: form } %>
-
           <%= render partial: "tos_field", locals: { form: form } %>
 
           <div class="actions">

--- a/app/views/devise/mailer/invite_minor.html.erb
+++ b/app/views/devise/mailer/invite_minor.html.erb
@@ -1,17 +1,13 @@
 <p class="email-greeting">
-  <%= t("greeting", scope: "decidim.kids.minor_notifications_mailer.confirmation", recipient: @user.email) %>
+  <%= raw t("greeting", scope: "decidim.kids.minor_notifications_mailer.confirmation", recipient: @user.email) %>
 </p>
 
 <p class="email-instructions">
   <%= t("body", scope: "decidim.kids.minor_notifications_mailer.confirmation") %>
 </p>
 
-<p class="email-instructions">
-  <%= t("body_2", scope: "decidim.kids.minor_notifications_mailer.confirmation") %>
-</p>
-
 <p class="email-button email-button__cta">
-  <%= link_to t("decidim.devise.mailer.invitation_instructions.accept"),
+  <%= link_to t("confirm", scope: "decidim.kids.minor_notifications_mailer.confirmation"),
               accept_invitation_url(@resource,
                                     invitation_token: @token,
                                     invite_redirect: decidim.root_path,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,6 +94,7 @@ en:
           verified: Verified
         new:
           create: Create minor account
+          help_text_email: Write here the child's e-mail
           title: Add a minor
           subtitle: "Fist step: Now you must fill in the form with the necessary information to create the minor's account"
         no_tutor_authorization: Minors module is misconfigured, please contact the

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,7 +79,7 @@ en:
         authorize:
           already_authorized: The minor account is already authorized.
           error: There was an error authorizing the minor account.
-          success: The minor account has been successfully authorized.
+          success: The minor account has been successfully authorized. An email have been sent to the minor's email address. Please confirm the email to finish the process
         create:
           invalid_age: We could not verify the minor account because the authorization
             method does not provide the birthday attribute or this one is not in the

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,7 +170,7 @@ en:
         no_tutor_authorization: Minors module is misconfigured, please contact the
           administrator.
         resend:
-          success: An email have been sent to the minor's email adress. Please confirm
+          success: An email have been sent to the minor's email address. Please confirm
             the email to finish the process
         tos_field:
           tos_agreement: You accept its Terms and Conditions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,6 +86,7 @@ en:
             accepted range.
         new:
           authorizing_html: You are verifying the minor <b>%{minor}</b>
+          help_text: "Second step: For security reasons, we need to check that the minor's details are correct and we can verify his or her identity on our census"
       minor_account:
         form:
           invalid_age: Invalid age

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,7 +79,9 @@ en:
         authorize:
           already_authorized: The minor account is already authorized.
           error: There was an error authorizing the minor account.
-          success: The minor account has been successfully authorized. An email have been sent to the minor's email address. Please confirm the email to finish the process
+          success: The minor account has been successfully authorized. An email have
+            been sent to the minor's email address. Please confirm the email to finish
+            the process
         create:
           invalid_age: We could not verify the minor account because the authorization
             method does not provide the birthday attribute or this one is not in the

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,7 +39,9 @@ en:
             accepted range.
         new:
           authorizing_html: You are verifying the minor <b>%{minor}</b>
-          help_text: "Second step: For security reasons, we need to check that the minor's details are correct and we can verify his or her identity on our census"
+          help_text: 'Second step: For security reasons, we need to check that the
+            minor''s details are correct and we can verify his or her identity on
+            our census'
       minor_account:
         form:
           invalid_age: Invalid age
@@ -96,12 +98,14 @@ en:
         new:
           create: Create minor account
           help_text_email: Write here the child's e-mail
+          subtitle: 'Fist step: Now you must fill in the form with the necessary information
+            to create the minor''s account'
           title: Add a minor
-          subtitle: "Fist step: Now you must fill in the form with the necessary information to create the minor's account"
         no_tutor_authorization: Minors module is misconfigured, please contact the
           administrator.
         resend:
-          success: Email was successfully sent
+          success: An email have been sent to the minor's email adress. Please confirm
+            the email to finish the process
         tos_field:
           tos_agreement: You accept its Terms and Conditions
         unverified:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,7 @@ en:
             accepted range.
         new:
           authorizing_html: You are verifying the minor <b>%{minor}</b>
+          help_text: "Second step: For security reasons, we need to check that the minor's details are correct and we can verify his or her identity on our census"
       minor_account:
         form:
           invalid_age: Invalid age

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,9 +95,12 @@ en:
         name: Verification pending minor account
       minor_notifications_mailer:
         confirmation:
-          body: Instructions
-          body_2: The account is "tutelated"
-          greeting: Welcome, %{recipient}!
+          body: Your legal guardian has authorised the creation of your account to
+            participate in the platform. Your account will be under guardianship until
+            you reach the legal age. You can now finalise the account creation by
+            confirming this email and following the instructions
+          confirm: Confirm email
+          greeting: Welcome, <b>%{recipient}</b>!
           sign_in: Sign in
           subject: Confirmation instructions
       minors_participation: Decidim Minors Participation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -142,6 +142,7 @@ en:
           verified: Verified
         new:
           create: Create minor account
+          help_text_email: Write here the child's e-mail
           title: Add a minor
           subtitle: "Fist step: Now you must fill in the form with the necessary information to create the minor's account"
         no_tutor_authorization: Minors module is misconfigured, please contact the

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,6 +143,7 @@ en:
         new:
           create: Create minor account
           title: Add a minor
+          subtitle: "Fist step: Now you must fill in the form with the necessary information to create the minor's account"
         no_tutor_authorization: Minors module is misconfigured, please contact the
           administrator.
         resend:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,6 +95,7 @@ en:
         new:
           create: Create minor account
           title: Add a minor
+          subtitle: "Fist step: Now you must fill in the form with the necessary information to create the minor's account"
         no_tutor_authorization: Minors module is misconfigured, please contact the
           administrator.
         resend:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,7 +86,9 @@ en:
             accepted range.
         new:
           authorizing_html: You are verifying the minor <b>%{minor}</b>
-          help_text: "Second step: For security reasons, we need to check that the minor's details are correct and we can verify his or her identity on our census"
+          help_text: 'Second step: For security reasons, we need to check that the
+            minor''s details are correct and we can verify his or her identity on
+            our census'
       minor_account:
         form:
           invalid_age: Invalid age
@@ -144,12 +146,14 @@ en:
         new:
           create: Create minor account
           help_text_email: Write here the child's e-mail
+          subtitle: 'Fist step: Now you must fill in the form with the necessary information
+            to create the minor''s account'
           title: Add a minor
-          subtitle: "Fist step: Now you must fill in the form with the necessary information to create the minor's account"
         no_tutor_authorization: Minors module is misconfigured, please contact the
           administrator.
         resend:
-          success: Email was successfully sent
+          success: An email have been sent to the minor's email adress. Please confirm
+            the email to finish the process
         tos_field:
           tos_agreement: You accept its Terms and Conditions
         unverified:

--- a/spec/commands/authorize_minor_spec.rb
+++ b/spec/commands/authorize_minor_spec.rb
@@ -7,7 +7,8 @@ module Decidim::Kids
   describe AuthorizeMinor do
     subject { described_class.new(handler) }
 
-    let(:minor) { create(:minor, :blocked, name: "Verification pending minor") }
+    let(:minor) { create(:minor, :blocked, name: "Verification pending minor", minor_data:) }
+    let!(:minor_data) { create(:minor_data) }
     let(:document_number) { "12345678X" }
     let(:birthday) { 12.years.ago }
     let(:handler) do

--- a/spec/commands/create_minor_account_spec.rb
+++ b/spec/commands/create_minor_account_spec.rb
@@ -18,8 +18,6 @@ module Decidim::Kids
           name: "Mike",
           email: "test@example.com",
           birthday: "01/11/2009",
-          password: "password123456",
-          password_confirmation: "password123456",
           tos_agreement: true
         }
       end

--- a/spec/commands/update_minor_account_spec.rb
+++ b/spec/commands/update_minor_account_spec.rb
@@ -6,17 +6,9 @@ module Decidim::Kids
   describe UpdateMinorAccount do
     let(:organization) { create :organization }
     let(:user) { create(:user, :confirmed, organization:) }
-    # let!(:minor) { create(:minor, name: "Pending verification minor", tutor: user, organization:) }
     let(:command) { described_class.new(form, minor) }
     let!(:minor_data) { create(:minor_data, name: "Marco", email: "marco@example.org", birthday: "01/11/2010") }
     let!(:minor) { create(:minor, name: "Pending verification minor", tutor: user, organization:, minor_data:) }
-    # let(:minor_data) do
-    #   {
-    #     name:,
-    #     email:,
-    #     birthday:
-    #   }
-    # end
 
     let(:form) do
       MinorAccountForm.from_params(

--- a/spec/commands/update_minor_account_spec.rb
+++ b/spec/commands/update_minor_account_spec.rb
@@ -6,23 +6,22 @@ module Decidim::Kids
   describe UpdateMinorAccount do
     let(:organization) { create :organization }
     let(:user) { create(:user, :confirmed, organization:) }
-    let(:minor) { create(:minor, name: "Pending verification minor", tutor: user, organization:) }
+    # let!(:minor) { create(:minor, name: "Pending verification minor", tutor: user, organization:) }
     let(:command) { described_class.new(form, minor) }
-
-    let(:minor_data) do
-      {
-        name:,
-        email:,
-        birthday:
-      }
-    end
+    let!(:minor_data) { create(:minor_data, name: "Marco", email: "marco@example.org", birthday: "01/11/2010") }
+    let!(:minor) { create(:minor, name: "Pending verification minor", tutor: user, organization:, minor_data:) }
+    # let(:minor_data) do
+    #   {
+    #     name:,
+    #     email:,
+    #     birthday:
+    #   }
+    # end
 
     let(:form) do
       MinorAccountForm.from_params(
         name:,
         email:,
-        password:,
-        password_confirmation:,
         birthday:,
         tos_agreement:
       )
@@ -31,17 +30,17 @@ module Decidim::Kids
     let(:name) { "Marco" }
     let(:email) { "marco@example.org" }
     let(:birthday) { "01/11/2010" }
-    let(:password) { nil }
-    let(:password_confirmation) { nil }
     let(:tos_agreement) { true }
 
     context "when valid" do
       it "updates the user's name" do
-        form.name = "Marco"
+        form.name = "Marco New"
 
-        expect { command.call }.to broadcast(:ok)
+        expect do
+          command.call
+        end.to change { minor.minor_data.reload.name }.from("Marco").to("Marco New")
+
         expect(minor.reload.name).to eq("Pending verification minor")
-        expect(minor.minor_data.reload.name).to eq("Marco")
       end
 
       it "updates the user's birthday" do
@@ -50,34 +49,6 @@ module Decidim::Kids
 
         expect { command.call }.to broadcast(:ok)
         expect(minor.minor_data.reload.birthday).to eq(date)
-      end
-
-      describe "when the password is present" do
-        it "updates the user's password" do
-          form.password = "decidim123123123"
-          form.password_confirmation = "decidim123123123"
-
-          expect { command.call }.to broadcast(:ok)
-          expect(minor.reload.password).to eq("decidim123123123")
-        end
-
-        it "shows password errors" do
-          form.password = "another123123123"
-          form.password_confirmation = "decidim123123123"
-
-          expect { command.call }.to broadcast(:invalid)
-          expect(minor.reload.password).to eq("decidim123456789")
-        end
-
-        context "when the minor user is invalid" do
-          before do
-            allow(minor).to receive(:valid?).and_return(false)
-          end
-
-          it "broadcasts invalid" do
-            expect { command.call }.to broadcast(:invalid)
-          end
-        end
       end
 
       describe "updating the email" do

--- a/spec/controllers/authorizations_controller_spec.rb
+++ b/spec/controllers/authorizations_controller_spec.rb
@@ -91,7 +91,7 @@ module Decidim::Kids
               end.not_to change(Decidim::Authorization, :count)
 
               expect(authorization).not_to be_blank
-              expect(flash[:notice]).to eq("The minor account has been successfully authorized.")
+              expect(flash[:notice]).to eq("The minor account has been successfully authorized. An email have been sent to the minor's email address. Please confirm the email to finish the process")
               expect(response).to redirect_to(return_path)
             end
           end

--- a/spec/controllers/user_minors_controller_spec.rb
+++ b/spec/controllers/user_minors_controller_spec.rb
@@ -163,7 +163,7 @@ module Decidim::Kids
       it "resends the email to the minor" do
         post :resend_invitation_to_minor, params: { id: minor.id }
 
-        expect(flash[:notice]).to have_content("Email was successfully sent")
+        expect(flash[:notice]).to have_content("An email have been sent to the minor's email address")
       end
     end
   end

--- a/spec/forms/minor_account_form_spec.rb
+++ b/spec/forms/minor_account_form_spec.rb
@@ -12,8 +12,6 @@ module Decidim::Kids
     let(:name) { "Marco" }
     let(:email) { "marco@example.org" }
     let(:birthday) { "01/11/2010" }
-    let(:password) { "password123456" }
-    let(:password_confirmation) { password }
     let(:tos_agreement) { true }
 
     let(:params) do
@@ -21,8 +19,6 @@ module Decidim::Kids
         name:,
         email:,
         birthday:,
-        password:,
-        password_confirmation:,
         tos_agreement:
       }
     end
@@ -66,26 +62,6 @@ module Decidim::Kids
         let(:email) { "" }
 
         it { is_expected.not_to be_valid }
-      end
-    end
-
-    describe "password" do
-      context "when password is blank" do
-        let(:password) { "" }
-
-        it { is_expected.to be_valid }
-      end
-
-      context "when the password is weak" do
-        let(:password) { "aaasssdddfff" }
-
-        it { is_expected.to be_invalid }
-      end
-
-      context "when the password confirmation is different" do
-        let(:password_confirmation) { "another thing" }
-
-        it { is_expected.to be_invalid }
       end
     end
 

--- a/spec/lib/tasks/kids_spec.rb
+++ b/spec/lib/tasks/kids_spec.rb
@@ -38,8 +38,8 @@ describe "kids:promote_minor_accounts", type: :task do
       context "and the minor reached the maximum minor age" do
         it "removes no longer minor accounts relations" do
           expect(organization.maximum_minor_age).to eq(13)
-          expect(minor_to_promote15.minor_age).to eq(15)
-          expect(minor_to_promote14.minor_age).to eq(14)
+          expect(minor_to_promote15.reload.minor_age).to eq(15)
+          expect(minor_to_promote14.reload.minor_age).to eq(14)
           task.execute
           expect(Decidim::Kids::MinorAccount.where(minor: minor_to_promote15)).to be_empty
           expect(Decidim::Kids::MinorAccount.where(minor: minor_to_promote14)).to be_empty
@@ -61,7 +61,7 @@ describe "kids:promote_minor_accounts", type: :task do
   context "when the minor is exactly the maximum minor age" do
     it "doesn't remove minor accounts relations" do
       expect(organization.maximum_minor_age).to eq(13)
-      expect(minor_to_promote13.minor_age).to eq(13)
+      expect(minor_to_promote13.reload.minor_age).to eq(13)
       task.execute
       expect(Decidim::Kids::MinorAccount.where(minor: minor_to_promote13)).not_to be_empty
       expect(Decidim::Kids::MinorData.where(user: minor_to_promote13)).not_to be_empty
@@ -71,7 +71,7 @@ describe "kids:promote_minor_accounts", type: :task do
   context "when the minor is under the maximum minor age" do
     it "doesn't remove minor accounts relations" do
       expect(organization.maximum_minor_age).to eq(13)
-      expect(minor_to_promote12.minor_age).to eq(12)
+      expect(minor_to_promote12.reload.minor_age).to eq(12)
       task.execute
       expect(Decidim::Kids::MinorAccount.where(minor: minor_to_promote12)).not_to be_empty
       expect(Decidim::Kids::MinorData.where(user: minor_to_promote12)).not_to be_empty

--- a/spec/shared/authorization_examples.rb
+++ b/spec/shared/authorization_examples.rb
@@ -22,14 +22,13 @@ shared_examples "everything is ok" do
     expect(minor.name).to eq("Verification pending minor")
     expect do
       perform_enqueued_jobs { subject.call }
-    end.to broadcast(:ok)
+    end.to broadcast(:ok).and change(minor, :name).to eq(minor.minor_data.name)
 
     minor.reload
     expect(last_email.to).to include(minor.email)
 
     expect(minor).not_to be_blocked
     expect(minor.name).not_to eq("Verification pending minor")
-    expect(minor.name).to eq(minor.minor_data.name)
   end
 
   context "when authorization goes wrong" do

--- a/spec/shared/controller_examples.rb
+++ b/spec/shared/controller_examples.rb
@@ -24,7 +24,7 @@ shared_examples "authorizes the minor" do
     end.to change(Decidim::Authorization, :count).by(1)
 
     expect(authorization).not_to be_blank
-    expect(flash[:notice]).to eq("The minor account has been successfully authorized.")
+    expect(flash[:notice]).to eq("The minor account has been successfully authorized. An email have been sent to the minor's email address. Please confirm the email to finish the process")
     expect(response).to redirect_to(return_path)
   end
 end

--- a/spec/shared/impersonation_examples.rb
+++ b/spec/shared/impersonation_examples.rb
@@ -36,7 +36,7 @@ shared_examples "user impersonate" do
 
         click_button("Impersonate")
 
-        expect(page).to have_content(minor.minor_data.name)
+        expect(page).to have_content("You are managing the participant")
         expect(page).to have_content("Close session")
       end
 

--- a/spec/shared/minors_table_examples.rb
+++ b/spec/shared/minors_table_examples.rb
@@ -18,7 +18,7 @@ shared_examples "minors table" do
 
     it "has email status 'Pending'" do
       expect(page).to have_content("Pending", count: 1)
-      expect(page).to have_link("Resend email", count: 1)
+      expect(page).to have_css(".icon--action-redo", count: 1)
     end
   end
 
@@ -36,12 +36,12 @@ shared_examples "minors table" do
 end
 
 shared_context "when minors verified" do
-  before do
-    click_link minor.minor_data.name
+  let(:minor) { create(:minor, tutor: user, organization:, sign_in_count:, name: "John") }
 
-    fill_in "Document number", with: "1234X"
+  before do
+    click_link "Verify"
+    fill_in "Document number", with: "1224X"
     fill_in "Postal code", with: "1234X"
-    page.find("#authorization_handler_birthday").click
     fill_in "Birthday", with: "01/11/2010"
 
     find(".actions button[type=submit]").click
@@ -56,6 +56,6 @@ shared_examples "resend email" do
   it "resends the invitation to the minor" do
     click_link "Resend email"
 
-    expect(page).to have_content("successfully")
+    expect(page).to have_content("email have been sent")
   end
 end

--- a/spec/shared/user_minors_crud_examples.rb
+++ b/spec/shared/user_minors_crud_examples.rb
@@ -8,17 +8,14 @@ shared_examples "creates minor accounts" do
       within "form.new_minor_account" do
         fill_in "Name", with: "John Tesla"
         fill_in "Email", with: "john@example.org"
-        page.find("#minor_account_birthday").click
+        find("#minor_account_birthday").click
         fill_in "Birthday", with: 12.years.ago.strftime("%d/%m/%Y")
-        fill_in "Password", match: :first, with: "mallorca123123123"
-        fill_in "Password confirmation", with: "mallorca123123123"
-        find("*[type=submit]").click
+        send_keys(:enter)
+        find("button[type=submit]").click
 
         expect(page).to have_content("must be accepted")
 
         page.find("#minor_tos_agreement").click
-        fill_in "Password", match: :first, with: "mallorca123123123"
-        fill_in "Password confirmation", with: "mallorca123123123"
         find("*[type=submit]").click
       end
 
@@ -30,7 +27,6 @@ shared_examples "creates minor accounts" do
 
       visit decidim_admin.officializations_path
       expect(page).to have_content("Pending verification minor account")
-      expect(page).not_to have_content(minor.minor_data.name)
     end
   end
 
@@ -46,42 +42,7 @@ shared_examples "creates minor accounts" do
 end
 
 shared_examples "updates minor accounts" do
-  it "can edit a minor with password" do
-    click_link "Edit"
-
-    within "form.edit_minor_account" do
-      fill_in "Name", with: "Nikola Tesla"
-      click_button "Change password"
-      page.find("#minor_account_birthday").click
-      fill_in "Birthday", with: 12.years.ago.strftime("%d/%m/%Y")
-      page.find("#minor_account_name").click # remove datepicker modal
-      fill_in "Email", with: "test@example.org"
-      fill_in "Password", match: :first, with: "mallorca123123123"
-      find("*[type=submit]").click
-    end
-
-    within_flash_messages do
-      expect(page).to have_content("Errors occurred while updating a minor's account")
-    end
-
-    within "form.edit_minor_account" do
-      fill_in "Password", match: :first, with: "mallorca123123123"
-      fill_in "Password confirmation", with: "mallorca123123123"
-      find("*[type=submit]").click
-    end
-
-    within_flash_messages do
-      expect(page).to have_content("successfully updated")
-    end
-
-    expect(page).to have_content("Nikola Tesla")
-
-    visit decidim_admin.officializations_path
-    expect(page).to have_content("Pending verification minor account")
-    expect(page).not_to have_content(minor.minor_data.name)
-  end
-
-  it "can edit a minor without password" do
+  it "can edit a minor" do
     click_link "Edit"
 
     within "form.edit_minor_account" do
@@ -118,7 +79,7 @@ shared_examples "deletes minor accounts" do
 end
 
 shared_examples "authorizes minor accounts" do
-  it "can edit a minor with password" do
+  it "can edit a minor" do
     expect(minor.name).to eq("Pending verification minor account")
     click_link "Verify"
 
@@ -133,12 +94,13 @@ shared_examples "authorizes minor accounts" do
     end
 
     minor.reload
+
     expect(minor.name).not_to eq("Pending verification minor account")
-    expect(minor.name).to eq(minor.minor_data.name)
     expect(page).to have_content(minor.name)
 
     visit decidim_admin.officializations_path
+
     expect(page).not_to have_content("Pending verification minor account")
-    expect(page).to have_content(minor.minor_data.name)
+    expect(page).to have_content(minor.name)
   end
 end

--- a/spec/shared/user_minors_examples.rb
+++ b/spec/shared/user_minors_examples.rb
@@ -41,13 +41,14 @@ shared_examples "user minors enabled" do
     end
 
     context "when there is minors" do
-      let!(:minor) { create(:minor, tutor: user, organization:) }
-      let!(:another_minor) { create(:minor, tutor: user, organization:) }
+      let!(:minors) { create_list(:minor, 2, tutor: user, organization:) }
 
-      it "minors names are listed" do
+      before do
         visit decidim_kids.user_minors_path
-        expect(page).to have_content(minor.minor_data.name)
-        expect(page).to have_content(another_minor.minor_data.name)
+      end
+
+      it "minors are listed in the table" do
+        expect(page).to have_css("tbody tr", count: 2)
       end
     end
 

--- a/spec/system/system/updates_organization_spec.rb
+++ b/spec/system/system/updates_organization_spec.rb
@@ -14,8 +14,8 @@ describe "Updates an organization", type: :system do
     create(:minors_organization_config,
            organization: another_organization,
            enable_minors_participation: false,
-           minimum_minor_age: 9,
-           maximum_minor_age: 12)
+           minimum_minor_age:,
+           maximum_minor_age:)
   end
 
   before do
@@ -41,6 +41,8 @@ describe "Updates an organization", type: :system do
 
   context "when minors config already exists" do
     let(:another_organization) { organization }
+    let(:minimum_minor_age) { 9 }
+    let(:maximum_minor_age) { 12 }
 
     it "has defined properties" do
       click_button "Show advanced settings"


### PR DESCRIPTION
fixes #34

- [x] Added help text under the title, help text below e-mail field, removed password fields:
<img src="https://user-images.githubusercontent.com/60363870/214676859-ee034e51-90cc-4330-9966-5164b2f0c439.jpg" width=70%>

- [x] Added help text about the second step:
<img src="https://user-images.githubusercontent.com/60363870/214677741-b7672b6f-35a4-4973-bba0-54309d9963d2.jpg" width=70%>

- [x] Replaced the text with an icon to resend:
<img src="https://user-images.githubusercontent.com/60363870/214681544-357131ee-cb63-4e50-8abd-e66eb68bcff5.jpg" width=70%>

- [x] Added a message with the next step after the authorization of a minor:
<img src="https://user-images.githubusercontent.com/60363870/214683150-7c85aee0-868f-438b-80f3-c6697858f18f.jpg" width=70%>


- [x] Changed instructions text and link
<img src="https://user-images.githubusercontent.com/60363870/214680560-6de5e92f-c5c5-4736-9b61-df75e19bdba5.jpg" width=70%>




