### PR TITLE
[GDPR 14] Minor activity log in my profile

### DIFF
--- a/app/controllers/concerns/decidim/kids/has_minor_activities_as_own.rb
+++ b/app/controllers/concerns/decidim/kids/has_minor_activities_as_own.rb
@@ -7,8 +7,9 @@ module Decidim
 
       included do
         alias_method :user_own_activities?, :own_activities?
+
         def own_activities?
-          user_own_activities? || current_user.minors.include?(user)
+          user_own_activities? || current_user&.minors&.include?(user)
         end
       end
     end

--- a/app/controllers/concerns/decidim/kids/has_minor_activities_as_own.rb
+++ b/app/controllers/concerns/decidim/kids/has_minor_activities_as_own.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Kids
+    module HasMinorActivitiesAsOwn
+      extend ActiveSupport::Concern
+
+      included do
+        alias_method :user_own_activities?, :own_activities?
+        def own_activities?
+          user_own_activities? || current_user.minors.include?(user)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/decidim/kids/has_minor_activities_as_own.rb
+++ b/app/controllers/concerns/decidim/kids/has_minor_activities_as_own.rb
@@ -9,7 +9,7 @@ module Decidim
         alias_method :user_own_activities?, :own_activities?
 
         def own_activities?
-          user_own_activities? || (current_user&.minors&.include?(user) && current_organization.minors_participation_enabled?)
+          user_own_activities? || (current_organization.minors_participation_enabled? && current_user&.minors&.include?(user))
         end
       end
     end

--- a/app/controllers/concerns/decidim/kids/has_minor_activities_as_own.rb
+++ b/app/controllers/concerns/decidim/kids/has_minor_activities_as_own.rb
@@ -9,7 +9,7 @@ module Decidim
         alias_method :user_own_activities?, :own_activities?
 
         def own_activities?
-          user_own_activities? || current_user&.minors&.include?(user)
+          user_own_activities? || (current_user&.minors&.include?(user) && current_organization.minors_participation_enabled?)
         end
       end
     end

--- a/app/views/decidim/kids/user_minors/_minor_tr.html.erb
+++ b/app/views/decidim/kids/user_minors/_minor_tr.html.erb
@@ -28,6 +28,12 @@
   </td>
 
   <td class="table-list__actions">
+
+      <%= icon_link_to "book", decidim.profile_activity_path(nickname: user.nickname),
+                       t("activity", scope: "decidim.profiles.show"), class: "action-icon" %>
+
+
+    <span class="action-space icon"></span>
     <% if allowed_to? :edit, :minor_accounts, minor_user: user %>
       <%= icon_link_to "pencil", decidim_kids.edit_user_minor_path(user.id),
                        t("edit", scope: "decidim.kids.user_minors.index"), class: "action-icon" %>

--- a/app/views/decidim/kids/user_minors/_minor_tr.html.erb
+++ b/app/views/decidim/kids/user_minors/_minor_tr.html.erb
@@ -28,7 +28,7 @@
   </td>
 
   <td class="table-list__actions">
-    <%= icon_link_to "book", decidim.profile_activity_path(nickname: user.nickname), t("activity", scope: "decidim.profiles.show"), class: "action-icon" %>
+    <%= icon_link_to "book", decidim.profile_activity_path(nickname: user.nickname), t("activity", scope: "decidim.kids.user_minors.index"), class: "action-icon" %>
     <span class="action-space icon"></span>
     <% if allowed_to? :edit, :minor_accounts, minor_user: user %>
       <%= icon_link_to "pencil", decidim_kids.edit_user_minor_path(user.id),

--- a/app/views/decidim/kids/user_minors/_minor_tr.html.erb
+++ b/app/views/decidim/kids/user_minors/_minor_tr.html.erb
@@ -28,11 +28,7 @@
   </td>
 
   <td class="table-list__actions">
-
-      <%= icon_link_to "book", decidim.profile_activity_path(nickname: user.nickname),
-                       t("activity", scope: "decidim.profiles.show"), class: "action-icon" %>
-
-
+    <%= icon_link_to "book", decidim.profile_activity_path(nickname: user.nickname), t("activity", scope: "decidim.profiles.show"), class: "action-icon" %>
     <span class="action-space icon"></span>
     <% if allowed_to? :edit, :minor_accounts, minor_user: user %>
       <%= icon_link_to "pencil", decidim_kids.edit_user_minor_path(user.id),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,7 @@ en:
           title: Edit minor account
         index:
           actions: Actions
+          activity: Activity
           add: Add a minor
           age: Age
           button_verify: Verify

--- a/lib/decidim/kids/engine.rb
+++ b/lib/decidim/kids/engine.rb
@@ -45,6 +45,7 @@ module Decidim
         config.to_prepare do
           Decidim::Verifications::ApplicationController.include(Decidim::Kids::NeedsAdultPermission)
           Decidim::Messaging::ConversationsController.include(Decidim::Kids::HasDecidimKidsPermissions)
+          Decidim::UserActivitiesController.include(Decidim::Kids::HasMinorActivitiesAsOwn)
         end
       end
 

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -37,7 +37,13 @@ checksums = [
       "/app/views/decidim/system/organizations/new.html.erb" => "ef9277c31e87f864e911a05d7ad0a333",
       "/app/views/decidim/system/organizations/edit.html.erb" => "a5fbf0df2106009878cbca6e36472cae"
     }
-  }
+  },
+  {
+    package: "decidim-kids",
+    files: {
+      "/app/controllers/concerns/decidim/kids/has_minor_activities_as_own.rb" => "05b8aa4b52972a0f85817fd4147b4021"
+    }
+  },
 ]
 
 describe "Overriden files", type: :view do

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -43,7 +43,7 @@ checksums = [
     files: {
       "/app/controllers/concerns/decidim/kids/has_minor_activities_as_own.rb" => "05b8aa4b52972a0f85817fd4147b4021"
     }
-  },
+  }
 ]
 
 describe "Overriden files", type: :view do

--- a/spec/shared/user_minor_activity_examples.rb
+++ b/spec/shared/user_minor_activity_examples.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+shared_context "when accessing activity page" do
+  before do
+    visit decidim.profile_activity_path(nickname: person.nickname)
+  end
+end
+
+shared_examples "displays private link" do
+  it "displays private link" do
+    expect(page).to have_content("Budgeting vote")
+  end
+end
+
+shared_examples "doesn't display private link" do
+  it "doesn't display private link" do
+    expect(page).not_to have_content("Budgeting vote")
+  end
+end

--- a/spec/system/user_minor_activity_spec.rb
+++ b/spec/system/user_minor_activity_spec.rb
@@ -97,4 +97,19 @@ describe "Test private activity of my minors", type: :system do
       end
     end
   end
+
+  context "when minors participation disabled" do
+    let(:enable_minors_participation) { false }
+
+    context "when the user is an adult" do
+      before do
+        login_as user, scope: :user
+      end
+
+      context "when visiting one of my minor activity page" do
+        include_context "when accessing activity page", let(:person) { minor }
+        it_behaves_like "doesn't display private link"
+      end
+    end
+  end
 end

--- a/spec/system/user_minor_activity_spec.rb
+++ b/spec/system/user_minor_activity_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared/user_minor_activity_examples"
+
+describe "Test private activity of my minors", type: :system do
+  let(:authorization_handler) { "dummy_authorization_handler" }
+  let(:organization) { create(:organization, available_authorizations: [authorization_handler]) }
+  let(:user) { create(:user, :admin, :confirmed, organization:) }
+  let!(:authorization) { create(:authorization, user:, name: authorization_handler) }
+  let(:other_user) { create(:user, :admin, :confirmed, organization:) }
+  let(:minor) { create(:minor, tutor: user, organization:) }
+  let(:other_minor) { create(:minor, tutor: other_user, organization:) }
+  let(:enable_minors_participation) { false }
+  let!(:minors_organization_config) { create(:minors_organization_config, organization:, enable_minors_participation:) }
+
+  before do
+    minor.confirm
+    other_minor.confirm
+    switch_to_host(organization.host)
+  end
+
+  context "when minors participation enabled" do
+    let(:enable_minors_participation) { true }
+
+    context "when you are not logged in" do
+      context "and visiting any user activity page" do
+        include_context "when accessing activity page", let(:person) { user }
+        it_behaves_like "doesn't display private link"
+      end
+    end
+
+    context "when the user is an adult" do
+      before do
+        login_as user, scope: :user
+      end
+
+      context "when accessing my minor accounts" do
+        before do
+          visit decidim_kids.user_minors_path
+        end
+
+        it "shows activity icon" do
+          expect(page).to have_css(".icon--book")
+        end
+
+        context "when accessing my first minor activity" do
+          before do
+            page.find(".icon--book").click
+          end
+
+          it "renders minor activity page" do
+            expect(page).to have_content("@#{user.minors[0].nickname}")
+          end
+        end
+      end
+
+      context "when accessing own activity page" do
+        include_context "when accessing activity page", let(:person) { user }
+        it_behaves_like "displays private link"
+      end
+
+      context "when accessing other adult activity page" do
+        include_context "when accessing activity page", let(:person) { other_user }
+        it_behaves_like "doesn't display private link"
+      end
+
+      context "when visiting one of my minor activity page" do
+        include_context "when accessing activity page", let(:person) { minor }
+        it_behaves_like "displays private link"
+      end
+
+      context "when visiting a minor who is not mine" do
+        include_context "when accessing activity page", let(:person) { other_minor }
+        it_behaves_like "doesn't display private link"
+      end
+    end
+
+    context "when the user is an minor" do
+      before do
+        login_as minor, scope: :user
+      end
+
+      context "when accessing own activity page" do
+        include_context "when accessing activity page", let(:person) { minor }
+        it_behaves_like "displays private link"
+      end
+
+      context "when accessing an adult activity page" do
+        include_context "when accessing activity page", let(:person) { other_user }
+        it_behaves_like "doesn't display private link"
+      end
+
+      context "when visiting other minor activity page" do
+        include_context "when accessing activity page", let(:person) { other_minor }
+        it_behaves_like "doesn't display private link"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #21

User can see public and private activity of his minors from own account.

- [x] As a guardian with a minor account associated, I can see the activity log of the minor from my account.
- [x] As a guardian with a minor account associated, I can see the activity done by the minor in a spaces exclusively for minors.